### PR TITLE
Tratamento de métodos ogr2ogr e csv com codificação difernte de utf8 e quebra de linha no formato dos.

### DIFF
--- a/data/SP/SaoPaulo/_pk035/make_conf.yaml
+++ b/data/SP/SaoPaulo/_pk035/make_conf.yaml
@@ -1,0 +1,33 @@
+pkid: 35
+pkversion: "001"
+schemaId_input:    ref035a
+schemaId_template: ref035a
+srid: 31984
+
+files:
+  -
+    p:    1
+    file: 8e7be760f94bb385bb1b6a47feee3afce9c0fcf48317b554834a5ac30bc5a0cf.zip
+    name: Edifícios
+  -
+    p:    2
+    file: bae2054448855305db0fc855d2852cd5a7b369481cc03aeb809a0c3c162a2c04.zip
+    name: Lotes
+
+layers:
+
+  building:
+    subtype: none
+    method: shp2sql
+    p: 1a
+    file: 1
+    orig_filename: SHP_edificacao
+    orig_subfilename: SIRGAS_SHP_edificacao
+
+  parcel:
+    subtype: full
+    method: shp2sql
+    p: 2a
+    file: 2
+    orig_filename: SIRGAS_SHP_LOTES
+    orig_subfilename: SIRGAS_SHP_LOTES

--- a/src/maketemplates/common003_shp2pgsql.mustache
+++ b/src/maketemplates/common003_shp2pgsql.mustache
@@ -12,3 +12,7 @@
 	@echo Executando csc2sql ...
 	psql $(pg_uri_db) -c "SELECT ingest.fdw_generate_direct_csv( '$(sandbox)/{{orig_filename}}.csv', '$(tabname)' )"
 {{/isCsv}}
+{{#isOgr}}
+	@echo Executando ogr2ogr ...
+	docker run --rm --network host -v $(sandbox):/tmp osgeo/gdal ogr2ogr -overwrite -f "PostgreSQL" PG:" dbname='$(pg_db)' host='localhost' port='5432' user='postgres' " "/tmp/{{orig_filename}}{{orig_ext}}" {{{orig_tabname}}} -nln $(tabname)
+{{/isOgr}}

--- a/src/maketemplates/common003_shp2pgsql.mustache
+++ b/src/maketemplates/common003_shp2pgsql.mustache
@@ -16,3 +16,7 @@
 	@echo Executando ogr2ogr ...
 	docker run --rm --network host -v $(sandbox):/tmp osgeo/gdal ogr2ogr -overwrite -f "PostgreSQL" PG:" dbname='$(pg_db)' host='localhost' port='5432' user='postgres' " "/tmp/{{orig_filename}}{{orig_ext}}" {{{orig_tabname}}} -nln $(tabname)
 {{/isOgr}}
+{{#isOgrWithShp}}
+	@echo Executando ogr2ogr  ...
+	docker run --rm --network host -v $(sandbox):/tmp osgeo/gdal ogr2ogr -overwrite -f "PostgreSQL" PG:" dbname='$(pg_db)' host='localhost' port='5432' user='postgres' " /tmp/{{{orig_tabname}}} {{{origtabname}}} -nln $(tabname)
+{{/isOgrWithShp}}

--- a/src/maketemplates/common003_shp2pgsql.mustache
+++ b/src/maketemplates/common003_shp2pgsql.mustache
@@ -20,3 +20,9 @@
 	@echo Executando ogr2ogr  ...
 	docker run --rm --network host -v $(sandbox):/tmp osgeo/gdal ogr2ogr -overwrite -f "PostgreSQL" PG:" dbname='$(pg_db)' host='localhost' port='5432' user='postgres' " /tmp/{{{orig_tabname}}} {{{orig_tabname}}} -nln $(tabname)
 {{/isOgrWithShp}}
+{{#isCsvNotUtf8AndDos}}
+    @echo Alterando codificação para UTF8 e o tipo de quebra de linha ...
+	iconv -f {{{csv_encoding}}} -t UTF-8 $(sandbox)/{{orig_filename}}.csv | dos2unix > $(sandbox)/{{orig_filename}}.unix_utf8.csv
+    @echo Executando csc2sql ...
+	psql $(pg_uri_db) -c "SELECT ingest.fdw_generate_direct_csv( '$(sandbox)/{{orig_filename}}.unix_utf8.csv', '$(tabname)' )"
+{{/isCsvNotUtf8AndDos}}

--- a/src/maketemplates/common003_shp2pgsql.mustache
+++ b/src/maketemplates/common003_shp2pgsql.mustache
@@ -18,5 +18,5 @@
 {{/isOgr}}
 {{#isOgrWithShp}}
 	@echo Executando ogr2ogr  ...
-	docker run --rm --network host -v $(sandbox):/tmp osgeo/gdal ogr2ogr -overwrite -f "PostgreSQL" PG:" dbname='$(pg_db)' host='localhost' port='5432' user='postgres' " /tmp/{{{orig_tabname}}} {{{origtabname}}} -nln $(tabname)
+	docker run --rm --network host -v $(sandbox):/tmp osgeo/gdal ogr2ogr -overwrite -f "PostgreSQL" PG:" dbname='$(pg_db)' host='localhost' port='5432' user='postgres' " /tmp/{{{orig_tabname}}} {{{orig_tabname}}} -nln $(tabname)
 {{/isOgrWithShp}}

--- a/src/maketemplates/common003_shp2pgsql_multiplefiles_zipped.mustache
+++ b/src/maketemplates/common003_shp2pgsql_multiplefiles_zipped.mustache
@@ -1,0 +1,6 @@
+{{#isShp}}
+	@echo Extraindo ...
+	cd $(sandbox);  7z x -y "{{orig_filename}}*"
+	@echo Executando shp2pgsql ...
+	cd $(sandbox);	find $(sandbox) -iname "{{orig_subfilename}}*.shp" -exec sh -c "shp2pgsql {{{method_opts}}} -s {{srid}} {} $(tabname) | psql -q $(pg_uri_db) 2> /dev/null" \;
+{{/isShp}}

--- a/src/maketemplates/make_ref027a.mustache.mk
+++ b/src/maketemplates/make_ref027a.mustache.mk
@@ -55,7 +55,7 @@ geoaddress: tabname = pk$(fullPkID)_p{{file}}_geoaddress
 geoaddress: makedirs $(part{{file}}_path)
 	@# pk{{pkid}}_p{{file}} - ETL extrating to PostgreSQL/PostGIS the "geoaddress" datatype (point with house_number but no via name)
 {{>common002_layerHeader}}
-	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}.*" ; chmod -R a+rx . > /dev/null
+	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}*" ; chmod -R a+rx . > /dev/null
 {{>common003_shp2pgsql}}
 {{>common001_pgAny_load}}
 	@echo FIM.
@@ -74,7 +74,7 @@ nsvia: tabname = pk$(fullPkID)_p{{file}}_nsvia
 nsvia: makedirs $(part{{file}}_path)
 	@# pk{{pkid}}_p{{file}} - ETL extrating to PostgreSQL/PostGIS the "nsvia" datatype (zone with name)
 {{>common002_layerHeader}}
-	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}.*"  ; chmod -R a+rx . > /dev/null
+	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}*"  ; chmod -R a+rx . > /dev/null
 {{>common003_shp2pgsql}}
 {{>common001_pgAny_load}}
 	@echo FIM.
@@ -93,7 +93,7 @@ via: tabname = pk$(fullPkID)_p{{file}}_via
 via: makedirs $(part{{file}}_path)
 	@# pk{{pkid}}_p{{file}} - ETL extrating to PostgreSQL/PostGIS the "via" datatype (street axes)
 {{>common002_layerHeader}}
-	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}.*"  ; chmod -R a+rx . > /dev/null
+	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}*"  ; chmod -R a+rx . > /dev/null
 {{>common003_shp2pgsql}}
 {{>common001_pgAny_load}}
 	@echo FIM.
@@ -112,7 +112,7 @@ parcel: tabname = pk$(fullPkID)_p{{file}}_parcel
 parcel: makedirs $(part{{file}}_path)
 	@# pk{{pkid}}_p{{file}} - ETL extrating to PostgreSQL/PostGIS the "parcel" datatype (street axes)
 {{>common002_layerHeader}}
-	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}.*" ; chmod -R a+rx . > /dev/null
+	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}*" ; chmod -R a+rx . > /dev/null
 {{>common003_shp2pgsql}}
 {{>common001_pgAny_load}}
 	@echo FIM.
@@ -130,7 +130,7 @@ block: tabname = pk$(fullPkID)_p{{file}}_block
 block: makedirs $(part{{file}}_path)
 	@# pk{{pkid}}_p{{file}} - ETL extrating to PostgreSQL/PostGIS the "block" datatype (street axes)
 {{>common002_layerHeader}}
-	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}.*" ; chmod -R a+rx . > /dev/null
+	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}*" ; chmod -R a+rx . > /dev/null
 {{>common003_shp2pgsql}}
 {{>common001_pgAny_load}}
 	@echo FIM.

--- a/src/maketemplates/make_ref035a.mustache.mk
+++ b/src/maketemplates/make_ref035a.mustache.mk
@@ -1,0 +1,179 @@
+##
+## Template file reference: preserv-BR/data/SP/SaoPaulo/_pk035
+## tplId: 035a
+##
+tplInputSchema_id=035a
+
+
+## BASIC CONFIG
+pg_io  ={{pg_io}}
+orig   ={{orig}}
+pg_uri ={{pg_uri}}
+sandbox_root={{sandbox}}
+need_commands= 7z v16+; psql v12+; shp2pgsql v3+; {{need_extra_commands}}
+srid   ={{srid}}
+
+pkid = {{pkid}}
+fullPkID={{pkid}}_{{pkversion}}
+sandbox=$(sandbox_root)/_pk$(fullPkID)
+
+## USER CONFIGS
+pg_db  ={{pg_db}}
+thisTplFile_root = {{thisTplFile_root}}
+
+## ## ## ## ## ## ##
+## THIS_MAKE, _pk{{pkid}}
+
+{{#files}}
+part{{p}}_file  ={{file}}
+part{{p}}_name  ={{name}}
+{{/files}}
+
+## COMPOSED VARS
+pg_uri_db   =$(pg_uri)/$(pg_db)
+{{#files}}
+part{{p}}_path  =$(orig)/$(part{{p}}_file)
+{{/files}}
+
+all:
+	@echo "=== Resumo deste makefile de recuperação de dados preservados ==="
+	@printf "Targets para a geração de layers:\n\tall_layers {{#layers_keys}}{{.}} {{/layers_keys}}\n"
+	@printf "Demais targets implementados:\n\tclean wget_files me\n"
+	@echo "A gereação de layers requer os seguintes comandos e versões:\n\t$(need_commands)"
+
+all_layers: {{#layers_keys}}{{.}} {{/layers_keys}}
+	@echo "--ALL LAYERS--"
+
+## ## ## ## ## ## ## ## ##
+## ## ## ## ## ## ## ## ##
+## Make targets of the Project Digital Preservation
+{{#layers}}
+
+{{#geoaddress}}## ## ## ## sponsored by Project AddressForAll
+geoaddress: layername = geoaddress_{{subtype}}
+geoaddress: tabname = pk$(fullPkID)_p{{file}}_geoaddress
+geoaddress: makedirs $(part{{file}}_path)
+	@# pk{{pkid}}_p{{file}} - ETL extrating to PostgreSQL/PostGIS the "geoaddress" datatype (point with house_number but no via name)
+{{>common002_layerHeader}}
+	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}*" ; chmod -R a+rx . > /dev/null
+{{>common003_shp2pgsql}}
+{{>common001_pgAny_load}}
+	@echo FIM.
+
+geoaddress-clean: tabname = pk$(fullPkID)_p{{file}}_geoaddress
+geoaddress-clean:
+	rm -f "$(sandbox)/{{orig_filename}}.*" || true
+	psql $(pg_uri_db) -c "DROP TABLE IF EXISTS $(tabname) CASCADE"
+{{/geoaddress}}
+
+{{#building}}## ## ## ## sponsored by Project AddressForAll
+building: layername = building_{{subtype}}
+building: tabname = pk$(fullPkID)_p{{file}}_building
+building: makedirs $(part{{file}}_path)
+	@# pk{{pkid}}_p{{file}} - ETL extrating to PostgreSQL/PostGIS the "building" datatype (point with house_number but no via name)
+{{>common002_layerHeader}}
+	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}*" ; chmod -R a+rx . > /dev/null
+{{>common003_shp2pgsql_multiplefiles_zipped}}
+{{>common001_pgAny_load}}
+	@echo FIM.
+
+building-clean: tabname = pk$(fullPkID)_p{{file}}_building
+building-clean:
+	rm -f "$(sandbox)/{{orig_filename}}.*" || true
+	psql $(pg_uri_db) -c "DROP TABLE IF EXISTS $(tabname) CASCADE"
+{{/building}}
+
+{{#nsvia}}## ## ## ## sponsored by Project AddressForAll
+nsvia: layername = nsvia_{{subtype}}
+nsvia: tabname = pk$(fullPkID)_p{{file}}_nsvia
+nsvia: makedirs $(part{{file}}_path)
+	@# pk{{pkid}}_p{{file}} - ETL extrating to PostgreSQL/PostGIS the "nsvia" datatype (zone with name)
+{{>common002_layerHeader}}
+	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}*"  ; chmod -R a+rx . > /dev/null
+{{>common003_shp2pgsql}}
+{{>common001_pgAny_load}}
+	@echo FIM.
+
+nsvia-clean: tabname = pk$(fullPkID)_p{{file}}_nsvia
+nsvia-clean:
+	rm -f "$(sandbox)/{{orig_filename}}.*" || true
+	psql $(pg_uri_db) -c "DROP TABLE IF EXISTS $(tabname) CASCADE;  DROP VIEW IF EXISTS vw_$(tabname) CASCADE;"
+{{/nsvia}}
+
+{{#via}}## ## ## ## sponsored by Project AddressForAll
+via: layername = via_{{subtype}}
+via: tabname = pk$(fullPkID)_p{{file}}_via
+via: makedirs $(part{{file}}_path)
+	@# pk{{pkid}}_p{{file}} - ETL extrating to PostgreSQL/PostGIS the "via" datatype (street axes)
+{{>common002_layerHeader}}
+	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}*"  ; chmod -R a+rx . > /dev/null
+{{>common003_shp2pgsql}}
+{{>common001_pgAny_load}}
+	@echo FIM.
+
+via-clean: tabname = pk$(fullPkID)_p{{file}}_via
+via-clean:
+	rm -f "$(sandbox)/{{orig_filename}}.*" || true
+	psql $(pg_uri_db) -c "DROP TABLE IF EXISTS $(tabname) CASCADE"
+{{/via}}
+
+{{#parcel}}## ## ## ## sponsored by Project AddressForAll
+parcel: layername = parcel_{{subtype}}
+parcel: tabname = pk$(fullPkID)_p{{file}}_parcel
+parcel: makedirs $(part{{file}}_path)
+	@# pk{{pkid}}_p{{file}} - ETL extrating to PostgreSQL/PostGIS the "parcel" datatype (street axes)
+{{>common002_layerHeader}}
+	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}*" ; chmod -R a+rx . > /dev/null
+{{>common003_shp2pgsql_multiplefiles_zipped}}
+{{>common001_pgAny_load}}
+	@echo FIM.
+
+parcel-clean: tabname = pk$(fullPkID)_p{{file}}_parcel
+parcel-clean:
+	rm -f "$(sandbox)/{{orig_filename}}.*" || true
+	psql $(pg_uri_db) -c "DROP TABLE IF EXISTS $(tabname) CASCADE"
+{{/parcel}}
+
+{{#block}}## ## ## ## sponsored by Project AddressForAll
+block: layername = block_{{subtype}}
+block: tabname = pk$(fullPkID)_p{{file}}_block
+block: makedirs $(part{{file}}_path)
+	@# pk{{pkid}}_p{{file}} - ETL extrating to PostgreSQL/PostGIS the "block" datatype (street axes)
+{{>common002_layerHeader}}
+	cd $(sandbox);  7z {{7z_opts}} x -y  $(part{{file}}_path) "{{orig_filename}}*" ; chmod -R a+rx . > /dev/null
+{{>common003_shp2pgsql}}
+{{>common001_pgAny_load}}
+	@echo FIM.
+
+block-clean: tabname = pk$(fullPkID)_p{{file}}_block
+block-clean:
+	rm -f "$(sandbox)/{{orig_filename}}.*" || true
+	psql $(pg_uri_db) -c "DROP TABLE IF EXISTS $(tabname) CASCADE"
+{{/block}}
+
+{{/layers}}
+## ## ## ## ## ## ## ## ##
+## ## ## ## ## ## ## ## ##
+
+makedirs: clean_sandbox
+	@mkdir -p $(sandbox_root)
+	@mkdir -p $(sandbox)
+	@mkdir -p $(pg_io)
+
+wget_files:
+	@echo "Under construction, need to check that orig path is not /var/www! or use orig=x [ENTER if not else ^C]"
+	@echo $(orig)
+	@read _ENTER_OK_
+	mkdir -p $(orig)
+{{#files}}
+	@cd $(orig); wget http://preserv.addressforall.org/download/{{file}}
+{{/files}}
+	@echo "Please, if orig not default, run 'make _target_ orig=$(orig)'"
+
+
+## ## ## ##
+
+clean_sandbox:
+	@rm -rf $(sandbox) || true
+
+clean: geoaddress-clean nsvia-clean via-clean


### PR DESCRIPTION
Foram removidos o caracter "." de comandos de extração e adiciona comando para tratar layers com método do tipo ogr2ogr, conforme issue em https://github.com/AddressForAll/digital-preservation-BR/issues/17  e https://github.com/AddressForAll/digital-preservation-BR/issues/18.

Depende https://github.com/digital-guard/preserv/pull/7.